### PR TITLE
Add tf2_eigen dependency to motion command package

### DIFF
--- a/spot_micro_motion_cmd/CMakeLists.txt
+++ b/spot_micro_motion_cmd/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf2
   tf2_ros
   tf2_geometry_msgs
+  tf2_eigen
 )
 
 add_subdirectory(libs/spot_micro_kinematics_cpp)
@@ -110,7 +111,7 @@ add_subdirectory(libs/spot_micro_kinematics_cpp)
 catkin_package(
   INCLUDE_DIRS include/spot_micro_motion_cmd
 #  LIBRARIES spot_micro_motion_cmd
-  CATKIN_DEPENDS roscpp std_msgs geometry_msgs tf2 tf2_ros
+  CATKIN_DEPENDS roscpp std_msgs geometry_msgs tf2 tf2_ros tf2_eigen
 #  DEPENDS system_lib
 )
 

--- a/spot_micro_motion_cmd/package.xml
+++ b/spot_micro_motion_cmd/package.xml
@@ -54,8 +54,9 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>tf2</build_depend>
-  <build_depend>tf2_ros</build_depend>	
-  <build_depend>tf2_geometry_msgs</build_depend>	
+  <build_depend>tf2_ros</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
+  <build_depend>tf2_eigen</build_depend>
   <build_export_depend>i2cpwm_board</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
@@ -63,6 +64,7 @@
   <build_export_depend>tf2</build_export_depend>
   <build_export_depend>tf2_ros</build_export_depend>
   <build_export_depend>tf2_geometry_msgs</build_export_depend>
+  <build_export_depend>tf2_eigen</build_export_depend>
   <exec_depend>i2cpwm_board</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
@@ -70,6 +72,7 @@
   <exec_depend>tf2</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>tf2_geometry_msgs</exec_depend>
+  <exec_depend>tf2_eigen</exec_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
## Summary
- add tf2_eigen to the catkin dependency list in the motion command package build files so the headers are available
- update the package manifest with tf2_eigen build, export, and run dependencies

## Testing
- catkin_make *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d05d2852ec832b993d52860985554e