### PR TITLE
Enhance display manager telemetry and timeline

### DIFF
--- a/display_manager/scripts/display_manager.py
+++ b/display_manager/scripts/display_manager.py
@@ -1,51 +1,13 @@
 #!/usr/bin/env python
 
-import rospy
-from std_msgs.msg import Int32MultiArray, ColorRGBA, Empty, String
+from datetime import datetime
 from enum import Enum
-import subprocess, time
+from typing import Callable, List, Optional, Sequence, Tuple
 
-class SystemMonitor:
-    def __init__(self):
-        self.ip = ""
-        self.cpu = ""
-        self.mem_usage = ""
-        self.disk = ""
-        self.temperature = ""
-        self.paused = False
-        self.update() # set initial values.
+import rospy
+from std_msgs.msg import ColorRGBA, Empty, Int32MultiArray, String
 
-    def update(self):
-        # Get IP address
-        cmd = "hostname -I | cut -d\' \' -f1 | head --bytes -1"
-        ipString = subprocess.check_output(cmd, shell=True).decode().strip()
-        self.ip = f"IP: {ipString}"
-
-        # Get CPU usage
-        cmd = "top -bn1 | grep load | awk '{printf \"%.2fLA\", $(NF-2)}'"
-        cpuString = subprocess.check_output(cmd, shell=True).decode().strip()
-        self.cpu = f"CPU: {cpuString}"
-
-        # Get memory usage
-        cmd = "free -m | awk 'NR==2{printf \"%.2f%%\", $3*100/$2 }'"
-        memString = subprocess.check_output(cmd, shell=True).decode().strip()
-        self.mem_usage = f"MEM: {memString}"
-
-        # Get disk usage
-        cmd = "df -h | awk '$NF==\"/\"{printf \"%d/%dGB\", $3,$2}'"
-        diskString = subprocess.check_output(cmd, shell=True).decode().strip()
-        self.disk = f"DISK: {diskString}"
-
-        # Get temperature
-        cmd = "vcgencmd measure_temp | cut -d '=' -f 2 | head --bytes -1"
-        tempString = subprocess.check_output(cmd, shell=True).decode().strip()
-        self.temperature = f"TEMP: {tempString}"
-
-    def pause(self):
-        self.paused = True
-
-    def resume(self):
-        self.paused = False
+from system_monitor import SystemMonitor
 
 
 RED = ColorRGBA(r=255.0, g=0.0, b=0.0, a=1.0)
@@ -54,100 +16,205 @@ BLUE = ColorRGBA(r=0.0, g=0.0, b=255.0, a=1.0)
 PURPLE = ColorRGBA(r=128.0, g=0.0, b=128.0, a=1.0)
 BLACK = ColorRGBA(r=0.0, g=0.0, b=0.0, a=1.0)
 
+
 class ScreenMode(Enum):
     MONITOR = 0
     ULTRASONIC = 1
     STATIC = 2
 
+
 class DisplayManager:
-    def __init__(self):
-        rospy.init_node('display_manager')
-        rospy.loginfo(f"Running Display Manager Node...")
+    def __init__(self) -> None:
+        rospy.init_node("display_manager")
+        rospy.loginfo("Running Display Manager Node...")
 
         self.current_color = BLACK
-        self.current_text = ''
+        self.current_text = ""
 
         self.screen_mode = ScreenMode.MONITOR
         self.button_taps = 0
 
         self.system_monitor = SystemMonitor()
+        self.system_monitor.annotate("Mode: monitor")
 
-        self.color_pub = rospy.Publisher('oled_color', ColorRGBA, queue_size=10)
-        self.text_pub = rospy.Publisher('oled_text', String, queue_size=10)
-        rospy.Subscriber('ultrasonic_data', Int32MultiArray, self.ultrasonic_callback)
-        rospy.Subscriber('button_press', Empty, self.button_callback)
-        rospy.Timer(rospy.Duration(5), self.publish_system_stats)
+        self.monitor_pages: Sequence[Callable[[dict], List[str]]] = (
+            self._render_overview,
+            self._render_peaks,
+            self._render_timeline,
+        )
+        self.monitor_page_index = 0
+        self.monitor_page_tick = 0
+        self.monitor_page_hold = 2  # updates before rotating to the next page
 
-    # Callback Methods
+        self.color_pub = rospy.Publisher("oled_color", ColorRGBA, queue_size=10)
+        self.text_pub = rospy.Publisher("oled_text", String, queue_size=10)
+        rospy.Subscriber("ultrasonic_data", Int32MultiArray, self.ultrasonic_callback)
+        rospy.Subscriber("button_press", Empty, self.button_callback)
 
-    def ultrasonic_callback(self, msg):
+        self.monitor_timer = rospy.Timer(rospy.Duration(2), self.publish_system_stats)
+
+    # ------------------------------------------------------------------
+    # Callbacks
+
+    def ultrasonic_callback(self, msg: Int32MultiArray) -> None:
         if self.screen_mode != ScreenMode.ULTRASONIC:
             return
-        # Parse the incoming message to extract the left and right distance values
-        left_dist, right_dist = msg.data[0], msg.data[1]
-        rospy.logdebug(f"Received data: {left_dist}, {right_dist}")
 
-        # Determine if the distance is close enough to trigger an alert
-        if (left_dist < 5 or right_dist < 5):
+        left_dist, right_dist = msg.data[0], msg.data[1]
+        rospy.logdebug(f"Received ultrasonic data: {left_dist}, {right_dist}")
+
+        if left_dist < 5 or right_dist < 5:
             self.current_color = RED
         else:
             self.current_color = GREEN
         self.publish_color()
 
-    def button_callback(self, msg):
+    def button_callback(self, _msg: Empty) -> None:
         self.button_taps += 1
         self.update_mode()
 
-    # Publish Methods
+    # ------------------------------------------------------------------
+    # Publishers
 
-    def publish_color(self):
+    def publish_color(self) -> None:
         self.color_pub.publish(self.current_color)
 
-    def publish_system_stats(self, event):
-        if self.system_monitor.paused:
+    def publish_system_stats(self, _event: Optional[rospy.TimerEvent]) -> None:
+        if self.screen_mode != ScreenMode.MONITOR:
             return
-        self.system_monitor.update()
-        stats_array = [
-            self.system_monitor.ip,
-            self.system_monitor.cpu, 
-            self.system_monitor.mem_usage, 
-            self.system_monitor.disk,
-            self.system_monitor.temperature
-        ]
-        stats_str = '|'.join(stats_array)
+
+        snapshot = self.system_monitor.update()
+        if not snapshot:
+            return
+
+        page_renderer = self.monitor_pages[self.monitor_page_index]
+        lines = page_renderer(snapshot)
+        stats_str = "|".join(lines)
         if self.current_text != stats_str:
-            rospy.logdebug(f"Printing Stats:\n {stats_str}")
+            rospy.logdebug(f"OLED update on page {self.monitor_page_index}: {lines}")
             self.text_pub.publish(stats_str)
             self.current_text = stats_str
 
-    # Helper Methods
+        self.monitor_page_tick += 1
+        if self.monitor_page_tick >= self.monitor_page_hold:
+            self.monitor_page_tick = 0
+            self.monitor_page_index = (self.monitor_page_index + 1) % len(self.monitor_pages)
 
-    def static_screen(self):
+    # ------------------------------------------------------------------
+    # Mode management
+
+    def static_screen(self) -> None:
         self.current_color = PURPLE
         self.publish_color()
-        
-    def update_mode(self):
-        # Prepare for transition.
+
+    def update_mode(self) -> None:
         if self.screen_mode == ScreenMode.MONITOR:
             self.system_monitor.pause()
-        
-        # Update mode.
-        modes =  list(ScreenMode)
-        index = self.button_taps % len(ScreenMode)
-        self.screen_mode = modes[index]
 
-        # Mode startup tasks.
+        modes = list(ScreenMode)
+        self.screen_mode = modes[self.button_taps % len(ScreenMode)]
+
         if self.screen_mode == ScreenMode.STATIC:
+            self.system_monitor.annotate("Mode: static")
             self.static_screen()
+        elif self.screen_mode == ScreenMode.ULTRASONIC:
+            self.system_monitor.annotate("Mode: ultrasonic")
+            self.current_color = BLUE
+            self.publish_color()
         elif self.screen_mode == ScreenMode.MONITOR:
+            self.system_monitor.annotate("Mode: monitor")
             self.current_color = BLACK
             self.publish_color()
             self.system_monitor.resume()
+            self.monitor_page_index = 0
+            self.monitor_page_tick = 0
             self.publish_system_stats(None)
-        
-if __name__ == '__main__':
+
+    # ------------------------------------------------------------------
+    # Page renderers
+
+    def _render_overview(self, snapshot: dict) -> List[str]:
+        now = snapshot["timestamp"]
+        uptime = self._format_uptime(snapshot["uptime_seconds"])
+        line1 = f"UP {uptime:>6} {now:%H:%M}"
+
+        cpu_percent = snapshot["cpu_percent"]
+        trend_symbol = {"up": "^", "down": "v", "steady": "~"}.get(snapshot["cpu_trend"], "~")
+        load_avg = snapshot["load_average"]
+        line2 = f"CPU {cpu_percent:>3.0f}% {trend_symbol}{load_avg:.2f}"
+
+        mem_percent = snapshot["mem_percent"]
+        line3 = f"MEM {mem_percent:>3.0f}% {self._format_bar(mem_percent)}"
+
+        disk_used = int(round(snapshot["disk_used"]))
+        disk_total = int(round(snapshot["disk_total"]))
+        disk_used = max(0, min(disk_used, 99))
+        disk_total = max(0, min(disk_total, 99))
+        temp = snapshot["temperature_c"]
+        temp_str = "--" if temp is None else f"{int(round(temp)):02d}"
+        line4 = f"DSK {disk_used:02}/{disk_total:02}G T{temp_str}"
+
+        return [line1, line2, line3, line4]
+
+    def _render_peaks(self, snapshot: dict) -> List[str]:
+        ip_address = snapshot["ip_address"]
+        line1 = f"NET {ip_address[:13]}"
+
+        line2 = self._format_peak_line("CPU^", snapshot.get("cpu_peak"), "%")
+        line3 = self._format_peak_line("MEM^", snapshot.get("mem_peak"), "%")
+        line4 = self._format_peak_line("TMP^", snapshot.get("temp_peak"), "C")
+        return [line1, line2, line3, line4]
+
+    def _render_timeline(self, snapshot: dict) -> List[str]:
+        boot_time = snapshot["boot_time"]
+        line1 = f"BOOT {boot_time:%m-%d %H:%M}"
+
+        events: List[Tuple] = [evt for evt in snapshot["events"] if not evt[1].startswith("Booted")]
+        recent = list(reversed(events[-3:]))
+        lines = [self._format_event_line(evt) for evt in recent]
+        while len(lines) < 3:
+            lines.append("--:-- (idle)")
+        return [line1] + lines[:3]
+
+    # ------------------------------------------------------------------
+    # Formatting helpers
+
+    @staticmethod
+    def _format_uptime(seconds: float) -> str:
+        total_seconds = int(seconds)
+        days, rem = divmod(total_seconds, 86400)
+        hours, rem = divmod(rem, 3600)
+        minutes, _ = divmod(rem, 60)
+        if days:
+            return f"{days}d{hours:02}h"
+        return f"{hours:02}h{minutes:02}m"
+
+    @staticmethod
+    def _format_bar(percent: float, width: int = 8) -> str:
+        filled = int(round(percent / 100.0 * width))
+        filled = max(0, min(width, filled))
+        return "#" * filled + "." * (width - filled)
+
+    @staticmethod
+    def _format_peak_line(label: str, peak: Optional[Tuple[float, datetime]], unit: str) -> str:
+        if not peak:
+            return f"{label} -- --:--"
+        value, when = peak
+        if when is None:
+            return f"{label} {value:>3.0f}{unit} --:--"
+        return f"{label} {value:>3.0f}{unit} {when:%H:%M}"
+
+    @staticmethod
+    def _format_event_line(event: Optional[Tuple[datetime, str]]) -> str:
+        if not event:
+            return "--:-- (idle)"
+        when, message = event
+        return f"{when:%H:%M} {message[:10]}"
+
+
+if __name__ == "__main__":
     try:
-        display_manager = DisplayManager()
+        DisplayManager()
         rospy.spin()
     except rospy.ROSInterruptException:
         pass

--- a/display_manager/scripts/system_monitor.py
+++ b/display_manager/scripts/system_monitor.py
@@ -1,46 +1,306 @@
+#!/usr/bin/env python
+
+import shutil
 import subprocess
-import time
+from collections import deque
+from datetime import datetime, timedelta
+from typing import Deque, Dict, Optional, Tuple
+
 import rospy
-from std_msgs.msg import String
+
+
+def _read_boot_time() -> datetime:
+    """Best-effort read of the system boot timestamp."""
+    try:
+        with open("/proc/uptime", "r", encoding="utf-8") as f:
+            uptime_seconds = float(f.readline().split()[0])
+        return datetime.now() - timedelta(seconds=uptime_seconds)
+    except (OSError, ValueError):
+        # Fall back to "now" if /proc/uptime is not available (e.g. on non-Linux)
+        return datetime.now()
+
 
 class SystemMonitor:
-    def __init__(self):
-        self.ip = ""
-        self.cpu = ""
-        self.mem_usage = ""
-        self.disk = ""
-        self.temperature = ""
-        self.paused = False
-        self.update() # set initial values.
+    """Collects system telemetry and keeps a boot-to-present event log."""
 
-    def update(self):
-        # Get IP address
-        cmd = "hostname -I | cut -d\' \' -f1 | head --bytes -1"
-        ipString = subprocess.check_output(cmd, shell=True).decode().strip()
-        self.ip = f"IP: {ipString}"
+    _EVENT_HISTORY = 9
 
-        # Get CPU usage
-        cmd = "top -bn1 | grep load | awk '{printf \"%.2fLA\", $(NF-2)}'"
-        cpuString = subprocess.check_output(cmd, shell=True).decode().strip()
-        self.cpu = f"CPU: {cpuString}"
+    def __init__(self) -> None:
+        self.boot_time: datetime = _read_boot_time()
+        self.paused: bool = False
 
-        # Get memory usage
-        cmd = "free -m | awk 'NR==2{printf \"%.2f%%\", $3*100/$2 }'"
-        memString = subprocess.check_output(cmd, shell=True).decode().strip()
-        self.mem_usage = f"MEM: {memString}"
+        # Runtime telemetry caches
+        self._last_cpu_total: Optional[int] = None
+        self._last_cpu_idle: Optional[int] = None
+        self._last_cpu_reading: Optional[float] = None
+        self._last_trend_percent: Optional[float] = None
+        self.cpu_history: Deque[float] = deque(maxlen=120)
 
-        # Get disk usage
-        cmd = "df -h | awk '$NF==\"/\"{printf \"%d/%dGB\", $3,$2}'"
-        diskString = subprocess.check_output(cmd, shell=True).decode().strip()
-        self.disk = f"DISK: {diskString}"
+        # Peak tracking since boot
+        self._peak_cpu: Optional[Tuple[float, datetime]] = None
+        self._peak_mem: Optional[Tuple[float, datetime]] = None
+        self._peak_temp: Optional[Tuple[float, datetime]] = None
 
-        # Get temperature
-        cmd = "vcgencmd measure_temp | cut -d '=' -f 2 | head --bytes -1"
-        tempString = subprocess.check_output(cmd, shell=True).decode().strip()
-        self.temperature = f"TEMP: {tempString}"
+        # Alert state toggles so that we only log crossings once.
+        self._high_cpu_active = False
+        self._high_mem_active = False
+        self._low_disk_active = False
+        self._high_temp_active = False
 
-    def pause(self):
-        self.paused = True
+        # Human facing state
+        self.ip_address: str = ""
+        self.timeline: Deque[Tuple[datetime, str]] = deque(maxlen=self._EVENT_HISTORY)
 
-    def resume(self):
-        self.paused = False
+        self._log_event(f"Booted {self.boot_time:%H:%M:%S}")
+        self._log_event("Display manager online")
+
+    # ------------------------------------------------------------------
+    # Public API
+
+    def update(self) -> Optional[Dict[str, object]]:
+        if self.paused:
+            return None
+
+        now = datetime.now()
+        uptime_seconds = (now - self.boot_time).total_seconds()
+
+        cpu_percent = self._read_cpu_percent()
+        load_avg = self._read_load_average()
+        mem_used, mem_total, mem_percent = self._read_memory()
+        disk_used, disk_total, disk_percent = self._read_disk()
+        temperature_c = self._read_temperature()
+        ip_address = self._read_ip_address()
+
+        trend = self._compute_trend(cpu_percent)
+        self.cpu_history.append(cpu_percent)
+
+        self._update_peaks(cpu_percent, mem_percent, temperature_c, now)
+        self._update_alerts(cpu_percent, mem_percent, disk_percent, temperature_c, now)
+
+        snapshot: Dict[str, object] = {
+            "timestamp": now,
+            "uptime_seconds": uptime_seconds,
+            "boot_time": self.boot_time,
+            "cpu_percent": cpu_percent,
+            "cpu_trend": trend,
+            "load_average": load_avg,
+            "mem_percent": mem_percent,
+            "mem_used": mem_used,
+            "mem_total": mem_total,
+            "disk_percent": disk_percent,
+            "disk_used": disk_used,
+            "disk_total": disk_total,
+            "temperature_c": temperature_c,
+            "ip_address": ip_address,
+            "events": list(self.timeline),
+            "cpu_peak": self._peak_cpu,
+            "mem_peak": self._peak_mem,
+            "temp_peak": self._peak_temp,
+        }
+        return snapshot
+
+    def pause(self) -> None:
+        if not self.paused:
+            self.paused = True
+            self._log_event("Monitor paused")
+
+    def resume(self) -> None:
+        if self.paused:
+            self.paused = False
+            self._log_event("Monitor resumed")
+
+    def annotate(self, message: str) -> None:
+        """Expose event logging so callers can annotate the timeline."""
+        self._log_event(message)
+
+    # ------------------------------------------------------------------
+    # Telemetry helpers
+
+    def _read_cpu_percent(self) -> float:
+        try:
+            with open("/proc/stat", "r", encoding="utf-8") as f:
+                cpu_line = f.readline()
+        except OSError:
+            return 0.0
+
+        if not cpu_line.startswith("cpu "):
+            return 0.0
+
+        parts = cpu_line.split()[1:]
+        if len(parts) < 8:
+            return 0.0
+
+        values = list(map(int, parts[:8]))
+        user, nice, system, idle, iowait, irq, softirq, steal = values
+        idle_all = idle + iowait
+        non_idle = user + nice + system + irq + softirq + steal
+        total = idle_all + non_idle
+
+        if self._last_cpu_total is None or self._last_cpu_idle is None:
+            self._last_cpu_total = total
+            self._last_cpu_idle = idle_all
+            self._last_cpu_reading = 0.0
+            return 0.0
+
+        total_delta = total - self._last_cpu_total
+        idle_delta = idle_all - self._last_cpu_idle
+        self._last_cpu_total = total
+        self._last_cpu_idle = idle_all
+
+        if total_delta <= 0:
+            return self._last_cpu_reading or 0.0
+
+        usage = (total_delta - idle_delta) / float(total_delta) * 100.0
+        usage = max(0.0, min(usage, 100.0))
+        self._last_cpu_reading = usage
+        return usage
+
+    def _read_load_average(self) -> float:
+        try:
+            with open("/proc/loadavg", "r", encoding="utf-8") as f:
+                return float(f.readline().split()[0])
+        except (OSError, ValueError):
+            return 0.0
+
+    def _read_memory(self) -> Tuple[float, float, float]:
+        mem_total_kb = 0.0
+        mem_available_kb = 0.0
+        try:
+            with open("/proc/meminfo", "r", encoding="utf-8") as f:
+                for line in f:
+                    if line.startswith("MemTotal"):
+                        mem_total_kb = float(line.split()[1])
+                    elif line.startswith("MemAvailable"):
+                        mem_available_kb = float(line.split()[1])
+                    if mem_total_kb and mem_available_kb:
+                        break
+        except (OSError, ValueError):
+            return 0.0, 0.0, 0.0
+
+        if mem_total_kb <= 0:
+            return 0.0, 0.0, 0.0
+
+        mem_used_kb = max(mem_total_kb - mem_available_kb, 0.0)
+        mem_percent = (mem_used_kb / mem_total_kb) * 100.0
+
+        mem_used_gb = mem_used_kb / (1024.0 * 1024.0)
+        mem_total_gb = mem_total_kb / (1024.0 * 1024.0)
+        return mem_used_gb, mem_total_gb, mem_percent
+
+    def _read_disk(self) -> Tuple[float, float, float]:
+        try:
+            usage = shutil.disk_usage("/")
+        except OSError:
+            return 0.0, 0.0, 0.0
+
+        used_gb = usage.used / (1024.0 ** 3)
+        total_gb = usage.total / (1024.0 ** 3)
+        percent = (usage.used / usage.total) * 100.0 if usage.total else 0.0
+        return used_gb, total_gb, percent
+
+    def _read_temperature(self) -> Optional[float]:
+        cmd = ["vcgencmd", "measure_temp"]
+        try:
+            output = subprocess.check_output(cmd, stderr=subprocess.DEVNULL).decode().strip()
+            if "=" in output:
+                temp_token = output.split("=")[-1]
+                return float(temp_token.replace("'C", ""))
+        except (subprocess.CalledProcessError, FileNotFoundError, ValueError):
+            pass
+
+        # Fallback to the thermal zone file if vcgencmd is unavailable.
+        thermal_path = "/sys/class/thermal/thermal_zone0/temp"
+        try:
+            with open(thermal_path, "r", encoding="utf-8") as f:
+                return float(f.readline()) / 1000.0
+        except (OSError, ValueError):
+            return None
+
+    def _read_ip_address(self) -> str:
+        cmd = "hostname -I | awk '{print $1}'"
+        try:
+            ip_candidate = subprocess.check_output(cmd, shell=True, stderr=subprocess.DEVNULL).decode().strip()
+        except subprocess.CalledProcessError:
+            ip_candidate = ""
+
+        if not ip_candidate:
+            ip_candidate = "No link"
+
+        if ip_candidate != self.ip_address:
+            self.ip_address = ip_candidate
+            self._log_event(f"IP {self.ip_address}")
+
+        return self.ip_address
+
+    # ------------------------------------------------------------------
+    # Trend, peak and alert bookkeeping
+
+    def _compute_trend(self, current: float) -> str:
+        previous = self._last_trend_percent
+        self._last_trend_percent = current
+        if previous is None:
+            return "steady"
+
+        delta = current - previous
+        if delta > 1.5:
+            return "up"
+        if delta < -1.5:
+            return "down"
+        return "steady"
+
+    def _update_peaks(self, cpu: float, mem: float, temp: Optional[float], when: datetime) -> None:
+        if self._peak_cpu is None or cpu > self._peak_cpu[0]:
+            self._peak_cpu = (cpu, when)
+        if self._peak_mem is None or mem > self._peak_mem[0]:
+            self._peak_mem = (mem, when)
+        if temp is not None:
+            if self._peak_temp is None or temp > self._peak_temp[0]:
+                self._peak_temp = (temp, when)
+
+    def _update_alerts(
+        self,
+        cpu: float,
+        mem: float,
+        disk_percent: float,
+        temp: Optional[float],
+        when: datetime,
+    ) -> None:
+        if cpu >= 85.0 and not self._high_cpu_active:
+            self._high_cpu_active = True
+            self._log_event(f"CPU high {cpu:.0f}%", when)
+        elif cpu < 75.0 and self._high_cpu_active:
+            self._high_cpu_active = False
+            self._log_event("CPU recovered", when)
+
+        if mem >= 80.0 and not self._high_mem_active:
+            self._high_mem_active = True
+            self._log_event(f"MEM high {mem:.0f}%", when)
+        elif mem < 70.0 and self._high_mem_active:
+            self._high_mem_active = False
+            self._log_event("MEM recovered", when)
+
+        if disk_percent >= 90.0 and not self._low_disk_active:
+            self._low_disk_active = True
+            self._log_event(f"Disk {disk_percent:.0f}%", when)
+        elif disk_percent < 80.0 and self._low_disk_active:
+            self._low_disk_active = False
+            self._log_event("Disk recovered", when)
+
+        if temp is not None:
+            if temp >= 70.0 and not self._high_temp_active:
+                self._high_temp_active = True
+                self._log_event(f"Temp high {temp:.0f}C", when)
+            elif temp < 60.0 and self._high_temp_active:
+                self._high_temp_active = False
+                self._log_event("Temp cooled", when)
+
+    # ------------------------------------------------------------------
+    # Timeline helpers
+
+    def _log_event(self, message: str, when: Optional[datetime] = None) -> None:
+        when = when or datetime.now()
+        trimmed = message.strip()
+        if not trimmed:
+            return
+        self.timeline.append((when, trimmed[:32]))
+        rospy.logdebug(f"[SystemMonitor] {when:%H:%M:%S} - {trimmed}")


### PR DESCRIPTION
## Summary
- replace the ad-hoc shell-command telemetry with a dedicated `SystemMonitor` module that captures CPU, memory, disk, temperature, IP, and uptime history from boot
- rotate the OLED output through overview, peak metrics, and timeline pages for a richer, legible presentation on the compact display
- surface mode changes and health alerts in an event log so operators can review notable system transitions since boot

## Testing
- python -m compileall -f display_manager/scripts

------
https://chatgpt.com/codex/tasks/task_e_68d551854dfc832baba524ca5f20ee67